### PR TITLE
dot graph

### DIFF
--- a/deeplink.cabal
+++ b/deeplink.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 
 Library
   ghc-options:         -O2 -Wall
-  exposed-modules:     System.FilePath.ByteString, DeepLink
+  exposed-modules:     System.FilePath.ByteString, DeepLink, DeepLink.Dot
   other-modules:       OrderedSet
   default-extensions:  NoImplicitPrelude
   other-extensions:    OverloadedStrings
@@ -35,6 +35,7 @@ executable deeplink
   default-extensions:  NoImplicitPrelude
   other-extensions:    CPP
   build-depends:       base
+                     , containers >=0.5 && <0.6
                      , optparse-applicative >=0.11 && <0.12
                      , process >=1.2 && <1.3
                      , base-compat

--- a/src/DeepLink/Dot.hs
+++ b/src/DeepLink/Dot.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+module DeepLink.Dot
+       ( genDot )
+       where
+
+import           Control.Monad (forM_)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS8
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import           Data.Set (Set)
+import           System.FilePath.ByteString (FilePath)
+import           System.IO (withFile, IOMode(..))
+
+import qualified DeepLink
+
+import           Prelude.Compat hiding (FilePath)
+
+quote :: ByteString -> ByteString
+quote = BS8.pack . show
+
+
+genDot :: Map DeepLink.Dependent (Set FilePath) -> FilePath -> IO ()
+genDot dependencies dotFilePath =
+    withFile (BS8.unpack dotFilePath) WriteMode $ \handle -> do
+      BS8.hPutStrLn handle "digraph G {"
+      forM_ (Map.toList dependencies) $ \(dependent, reqObjFiles) ->
+        forM_ reqObjFiles $ \objFile ->
+          BS8.hPutStrLn handle $ mconcat
+          [ "\t"
+          , case dependent of
+                  DeepLink.CmdLine -> "commandline"
+                  DeepLink.ObjFile o -> quote o
+          , " -> "
+          , quote objFile
+          , ";" ]
+      BS8.hPutStrLn handle "}"

--- a/test/test-order.hs
+++ b/test/test-order.hs
@@ -8,7 +8,7 @@ import           Control.Monad (unless)
 import qualified Data.ByteString.Char8 as BS8
 import           Data.List ((\\))
 import           Data.Monoid ((<>))
-import           DeepLink (deepLink)
+import           DeepLink (deepLink, DeepLinkResult(..))
 import           System.FilePath (takeDirectory, (</>))
 import           System.IO (Handle, openTempFile, hClose)
 import           System.Process
@@ -45,7 +45,8 @@ main =
     withTempFile "file.o" $ \(oPath, _) ->
     do
         _ <- readProcess "gcc" ["-o", oPath, "-c", "-xc", "-I", myDir </> "../include", "-"] prog
-        fileList <- deepLink "." [BS8.pack oPath]
+        -- TODO: don't ignore deps! check them.
+        DeepLinkResult _deps fileList <- deepLink "." [BS8.pack oPath]
         let expected = map BS8.pack $ oPath : ["-l" <> show i | i <- order \\ prunes]
         let unlinesStr = unlines . map BS8.unpack
         unless (expected == fileList) $


### PR DESCRIPTION
Add --graph FILE and --dry-run to allow producing a dot file of dependencies with/without actually running the linker command